### PR TITLE
semantic token을 css variables로 변환하는 기능 추가

### DIFF
--- a/packages/styled/__tests__/theme.test.ts
+++ b/packages/styled/__tests__/theme.test.ts
@@ -3,6 +3,7 @@ import {
   getValueByPath,
   joinWithHyphen,
   isObject,
+  createCssVars,
 } from '@danji/styled';
 
 describe('toCustomProperties', () => {
@@ -188,6 +189,67 @@ describe('getValueByPath', () => {
     testCases.forEach(({ key, expected, fallback }) => {
       const result = getValueByPath(colors, key, fallback);
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('cssVars', () => {
+    it('should convert tokens to cssVars', () => {
+      const theme = {
+        colors: {
+          gray: {
+            '50': '#f9fafa',
+            '100': '#f1f1f2',
+            '200': '#e6e7e9',
+            '300': '#d2d4d7',
+            '400': '#a9adb2',
+            '500': '#797f88',
+            '600': '#4d5560',
+            '700': '#2e3744',
+            '800': '#19202b',
+            '900': '#141a23',
+          },
+        },
+      };
+
+      const result = createCssVars(theme);
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "--dj-colors-gray-100": "#f1f1f2",
+          "--dj-colors-gray-200": "#e6e7e9",
+          "--dj-colors-gray-300": "#d2d4d7",
+          "--dj-colors-gray-400": "#a9adb2",
+          "--dj-colors-gray-50": "#f9fafa",
+          "--dj-colors-gray-500": "#797f88",
+          "--dj-colors-gray-600": "#4d5560",
+          "--dj-colors-gray-700": "#2e3744",
+          "--dj-colors-gray-800": "#19202b",
+          "--dj-colors-gray-900": "#141a23",
+        }
+      `);
+    });
+
+    it('should convert semantic tokens to cssVars', () => {
+      const theme = {
+        sematicTokens: {
+          text: {
+            primary: {
+              _light: 'black',
+              _dark: 'white',
+            },
+          },
+        },
+      };
+
+      const result = createCssVars(theme);
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "--dj-colors-text-primary": "black",
+          "[data-theme=dark]": {
+            "--dj-colors-text-primary": "white",
+          },
+        }
+      `);
     });
   });
 });

--- a/packages/styled/__tests__/theme.test.ts
+++ b/packages/styled/__tests__/theme.test.ts
@@ -1,5 +1,8 @@
-import { join } from '@danji/styled/utils';
-import { toCustomProperties, getValueByPath } from '@danji/styled/theme';
+import {
+  toCustomProperties,
+  getValueByPath,
+  joinWithHyphen,
+} from '@danji/styled';
 
 describe('toCustomProperties', () => {
   const colors = {
@@ -65,7 +68,10 @@ describe('toCustomProperties', () => {
   });
 
   it('should handle prefix', () => {
-    const customProperties = toCustomProperties(colors, join('dj', 'colors'));
+    const customProperties = toCustomProperties(
+      colors,
+      joinWithHyphen('dj', 'colors'),
+    );
 
     expect(customProperties).toEqual({
       'dj-colors-gray-100': '#f8f9fa',
@@ -80,6 +86,28 @@ describe('toCustomProperties', () => {
       'dj-colors-blue': '#007bff',
       'dj-colors-red': '#dc3545',
       'dj-colors-green': '#28a745',
+    });
+  });
+
+  it('should handle delimiter', () => {
+    const delimiterCase = {
+      primary: {
+        blue: '#007bff',
+        red: '#dc3545',
+      },
+    };
+
+    const delimiter = '.';
+
+    const customProperties = toCustomProperties(
+      delimiterCase,
+      'colors',
+      delimiter,
+    );
+
+    expect(customProperties).toEqual({
+      'colors.primary.blue': '#007bff',
+      'colors.primary.red': '#dc3545',
     });
   });
 });

--- a/packages/styled/__tests__/theme.test.ts
+++ b/packages/styled/__tests__/theme.test.ts
@@ -2,6 +2,7 @@ import {
   toCustomProperties,
   getValueByPath,
   joinWithHyphen,
+  isObject,
 } from '@danji/styled';
 
 describe('toCustomProperties', () => {
@@ -90,14 +91,13 @@ describe('toCustomProperties', () => {
   });
 
   it('should handle delimiter', () => {
+    const delimiter = '.';
     const delimiterCase = {
       primary: {
         blue: '#007bff',
         red: '#dc3545',
       },
     };
-
-    const delimiter = '.';
 
     const customProperties = toCustomProperties(
       delimiterCase,
@@ -108,6 +108,27 @@ describe('toCustomProperties', () => {
     expect(customProperties).toEqual({
       'colors.primary.blue': '#007bff',
       'colors.primary.red': '#dc3545',
+    });
+  });
+
+  it('should handle halt condition', () => {
+    const delimiter = '.';
+    const haltCase = {
+      primary: {
+        blue: '#007bff',
+        red: '#dc3545',
+      },
+    };
+
+    const customProperties = toCustomProperties(haltCase, 'colors', delimiter, {
+      halt: (value) => isObject(value),
+    });
+
+    expect(customProperties).toEqual({
+      'colors.primary': {
+        blue: '#007bff',
+        red: '#dc3545',
+      },
     });
   });
 });

--- a/packages/styled/src/providers.tsx
+++ b/packages/styled/src/providers.tsx
@@ -8,7 +8,7 @@ import {
 } from '@emotion/react';
 import { THEME, toCustomProperties, toVarDefinition } from './theme';
 import { CssVariablesProps, ThemeWithCssVars } from './providers.types';
-import { join } from './utils';
+import { joinWithHyphen } from './utils';
 
 const jsx: typeof React.createElement = <P extends object>(
   type: React.FunctionComponent<P> | React.ComponentClass<P> | string,
@@ -37,7 +37,10 @@ export const customTheme = <T extends Record<string, any>>(theme: T) => {
   const { colors } = theme;
 
   const flattenTokens = {
-    ...toCustomProperties(colors, toVarDefinition(join(THEME.KEY, 'colors'))),
+    ...toCustomProperties(
+      colors,
+      toVarDefinition(joinWithHyphen(THEME.KEY, 'colors')),
+    ),
   };
 
   Object.assign(theme, {

--- a/packages/styled/src/providers.types.ts
+++ b/packages/styled/src/providers.types.ts
@@ -7,3 +7,21 @@ export interface CssVariablesProps {
 export type ThemeWithCssVars<T> = T & {
   cssVars: Dict;
 };
+
+export type NormalToken = string | number;
+
+export type NormalizedToken = {
+  _light: NormalToken;
+};
+
+export type SemanticToken = NormalizedToken & {
+  _dark?: NormalToken;
+};
+
+export type DesignToken = NormalToken | SemanticToken | DesignTokenObject;
+
+export type DesignTokens = Record<string, DesignToken>;
+
+export interface DesignTokenObject {
+  [key: string]: DesignToken;
+}

--- a/packages/styled/src/theme/base.ts
+++ b/packages/styled/src/theme/base.ts
@@ -4,14 +4,15 @@ import { JSONObject, JSONValue } from './base.types';
 export const toCustomProperties = (
   obj: Record<string, any>,
   prefix?: string,
+  delimiter = '-',
 ) => {
   const next: Record<string, any> = {};
 
   Object.entries(obj).forEach(([key, value]) => {
-    const name = join(prefix, key);
+    const name = join(delimiter, prefix, key);
 
     if (isObject(value)) {
-      const nestedObj = toCustomProperties(value, name);
+      const nestedObj = toCustomProperties(value, name, delimiter);
       Object.assign(next, nestedObj);
     } else {
       next[name] = value;

--- a/packages/styled/src/theme/base.ts
+++ b/packages/styled/src/theme/base.ts
@@ -1,23 +1,37 @@
 import { isObject, join, splitBySeparator } from '../utils';
 import { JSONObject, JSONValue } from './base.types';
 
+interface CustomPropertiesOptions {
+  halt?: (value: any) => boolean;
+}
+
 export const toCustomProperties = (
-  obj: Record<string, any>,
+  obj: JSONObject,
   prefix?: string,
   delimiter = '-',
+  options: CustomPropertiesOptions = {},
 ) => {
-  const next: Record<string, any> = {};
+  const { halt } = options;
+  const next: JSONObject = {};
 
-  Object.entries(obj).forEach(([key, value]) => {
+  const transformObjectEntry = (key: string, value: any) => {
     const name = join(delimiter, prefix, key);
 
-    if (isObject(value)) {
-      const nestedObj = toCustomProperties(value, name, delimiter);
-      Object.assign(next, nestedObj);
+    if (isObject(value) && halt?.(value)) {
+      Object.assign(next, { [name]: value });
     } else {
-      next[name] = value;
+      const nestedObj = isObject(value)
+        ? toCustomProperties(value, name, delimiter, options)
+        : { [name]: value };
+
+      Object.assign(next, nestedObj);
     }
-  });
+  };
+
+  Object.entries(obj).forEach(([key, value]) =>
+    transformObjectEntry(key, value),
+  );
+
   return next;
 };
 

--- a/packages/styled/src/theme/base.ts
+++ b/packages/styled/src/theme/base.ts
@@ -6,7 +6,7 @@ interface CustomPropertiesOptions {
 }
 
 export const toCustomProperties = (
-  obj: JSONObject,
+  obj: JSONObject = {},
   prefix?: string,
   delimiter = '-',
   options: CustomPropertiesOptions = {},

--- a/packages/styled/src/theme/constants.ts
+++ b/packages/styled/src/theme/constants.ts
@@ -1,8 +1,9 @@
 import { Theme } from '@danji/components';
-import { colors } from '../variables';
+import { colors, sematicTokens } from '../variables';
 
 export const DJ_DEFAULT_THEME = {
   colors,
+  sematicTokens,
   components: Theme,
 } as const;
 
@@ -10,3 +11,16 @@ export const THEME = {
   KEY: 'dj',
   DEFAULT_KEY: '__default',
 } as const;
+
+export const TOKEN_ALIASES = {
+  LIGHT: '_light',
+  DARK: '_dark',
+} as const;
+
+export const TOKEN_PSEUDO_CLASSES = {
+  [TOKEN_ALIASES.DARK]: '[data-theme=dark]',
+} as const;
+
+export type PseudoKeys = keyof typeof TOKEN_PSEUDO_CLASSES;
+
+export const pseudoKeys = Object.values(TOKEN_ALIASES);

--- a/packages/styled/src/theme/constants.ts
+++ b/packages/styled/src/theme/constants.ts
@@ -23,4 +23,6 @@ export const TOKEN_PSEUDO_CLASSES = {
 
 export type PseudoKeys = keyof typeof TOKEN_PSEUDO_CLASSES;
 
+export type PseudoAliases = (typeof TOKEN_ALIASES)[keyof typeof TOKEN_ALIASES];
+
 export const pseudoKeys = Object.values(TOKEN_ALIASES);

--- a/packages/styled/src/theme/cssVar.ts
+++ b/packages/styled/src/theme/cssVar.ts
@@ -1,9 +1,9 @@
-import { join } from '../utils';
+import { joinWithHyphen } from '../utils';
 
 export const toVarFunc = (value: string) => `var(${value})`;
 
 export const toVarDefinition = (value: string, prefix?: string) =>
-  `--${join(prefix, value)}`;
+  `--${joinWithHyphen(prefix, value)}`;
 
 export const tokenToCssVarFunc = (token: string | number): string =>
   toVarFunc(String(token).replace(/\./g, '-'));

--- a/packages/styled/src/utils/arrayUtils.ts
+++ b/packages/styled/src/utils/arrayUtils.ts
@@ -1,0 +1,5 @@
+export const join = (delimiter: string, ...args: (string | undefined)[]) =>
+  args.filter(Boolean).join(delimiter);
+
+export const joinWithHyphen = (...args: (string | undefined)[]) =>
+  join('-', ...args);

--- a/packages/styled/src/utils/assertion.ts
+++ b/packages/styled/src/utils/assertion.ts
@@ -1,7 +1,9 @@
-export const isArray = (val: any) => Array.isArray(val);
+export const isNonNull = <T>(val: T) => val !== null && val !== undefined;
 
-export const isObject = (val: any) =>
-  val !== null && typeof val === 'object' && !isArray(val);
+export const isArray = <T>(val: T) => Array.isArray(val);
+
+export const isObject = <T>(val: T) =>
+  isNonNull(val) && typeof val === 'object' && !isArray(val);
 
 export const isFunction = (value: any): value is (...args: any[]) => any =>
   typeof value === 'function';

--- a/packages/styled/src/utils/index.ts
+++ b/packages/styled/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './strUtils';
+export * from './arrayUtils';
 export * from './assertion';

--- a/packages/styled/src/utils/strUtils.ts
+++ b/packages/styled/src/utils/strUtils.ts
@@ -1,5 +1,2 @@
 export const splitBySeparator = (str: string, separator: string) =>
   str.split(separator);
-
-export const join = (...args: (string | undefined)[]) =>
-  args.filter(Boolean).join('-');

--- a/packages/styled/src/variables.ts
+++ b/packages/styled/src/variables.ts
@@ -146,3 +146,12 @@ export const colors = {
     '900': '#123662',
   },
 };
+
+export const sematicTokens = {
+  text: {
+    primary: {
+      _light: 'black',
+      _dark: 'white',
+    },
+  },
+};


### PR DESCRIPTION
### Description
- semantic token을 css variables로 변환하는 기능 추가


### Checklist

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
