### PR TITLE
컴포넌트의 색상이 테마에 맞게 변경되도록 기능 수정

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,12 +4,13 @@ import { useDarkMode } from 'storybook-dark-mode';
 import { themes } from '@storybook/theming';
 import { DocsContainer, DocsContainerProps } from '@storybook/addon-docs';
 
-import { ColorThemeProvider } from '@danji/components';
+import { ColorThemeProvider, setDataset } from '@danji/components';
 import { CssReset, DJ_DEFAULT_THEME, ThemeProvider } from '@danji/styled';
 
 function CustomDjProvider(props: PropsWithChildren) {
   const { children } = props;
   const storybookDarkMode = useDarkMode();
+  const theme = storybookDarkMode ? 'dark' : 'light';
 
   /**
    * storybook-dark-mode issue
@@ -23,9 +24,14 @@ function CustomDjProvider(props: PropsWithChildren) {
     document.body.style.backgroundColor = backgroundColor || 'inherit';
   }, [storybookDarkMode]);
 
+  // 외부에서 테마 상태를 관리하는 경우에는 외부에서 date-set을 관리
+  useEffect(() => {
+    setDataset(theme);
+  }, [theme]);
+
   return (
     <ThemeProvider theme={DJ_DEFAULT_THEME}>
-      <ColorThemeProvider value={storybookDarkMode ? 'dark' : 'light'}>
+      <ColorThemeProvider value={theme}>
         <CssReset />
         {children}
       </ColorThemeProvider>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -24,7 +24,7 @@ function CustomDjProvider(props: PropsWithChildren) {
     document.body.style.backgroundColor = backgroundColor || 'inherit';
   }, [storybookDarkMode]);
 
-  // 외부에서 테마 상태를 관리하는 경우에는 외부에서 date-set을 관리
+  // 외부에서 테마 상태를 관리하는 경우에는 외부에서 data attributes를 관리
   useEffect(() => {
     setDataset(theme);
   }, [theme]);

--- a/packages/components/src/ColorTheme/ColorThemeProvider.tsx
+++ b/packages/components/src/ColorTheme/ColorThemeProvider.tsx
@@ -64,6 +64,8 @@ function ColorThemeProvider(props: ColorThemeProviderProps) {
       triggerFirstLoad: false,
     },
     (matches) => {
+      if (!isSystemTheme(colorTheme)) return;
+
       const nextColorTheme = matches ? COLOR_THEME.DARK : COLOR_THEME.LIGHT;
       setSystemColorTheme(nextColorTheme);
       setDataset(nextColorTheme);

--- a/packages/components/src/ColorTheme/ColorThemeProvider.tsx
+++ b/packages/components/src/ColorTheme/ColorThemeProvider.tsx
@@ -22,7 +22,7 @@ interface ColorThemeProviderProps {
 }
 
 function ColorThemeProvider(props: ColorThemeProviderProps) {
-  const { value, children } = props;
+  const { value: externalTheme, children } = props;
 
   const [colorTheme, setColorTheme] = useState<ColorThemeWithSystem>(() =>
     getColorTheme(storageManager, DEFAULT_COLOR_MODE),
@@ -45,9 +45,10 @@ function ColorThemeProvider(props: ColorThemeProviderProps) {
     ? systemColorTheme
     : (colorTheme as ColorTheme);
 
-  // data attributes initalize
+  // data attributes initialize
   useEffect(() => {
     const initColorTheme = colorTheme;
+    if (externalTheme) return;
 
     if (isSystemTheme(initColorTheme)) {
       const systemTheme = getSystemTheme();
@@ -72,9 +73,9 @@ function ColorThemeProvider(props: ColorThemeProviderProps) {
   // 최종적으로 제공하는 인터페이스
   const context = useMemo(
     () =>
-      value
+      externalTheme
         ? {
-            colorTheme: value,
+            colorTheme: externalTheme,
             toggleColorTheme: () => {},
             setColorTheme: () => {},
           }
@@ -89,7 +90,7 @@ function ColorThemeProvider(props: ColorThemeProviderProps) {
             },
             setColorTheme: handleSetColorTheme,
           },
-    [theme, value],
+    [theme, externalTheme],
   );
 
   return (

--- a/packages/components/src/ColorTheme/ColorThemeProvider.tsx
+++ b/packages/components/src/ColorTheme/ColorThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 import { useMediaQuery } from '@danji/components/hooks';
 import { ColorThemeContext } from './colorThemeContext';
 import {
@@ -12,6 +12,7 @@ import {
   isDarkTheme,
   isSystemTheme,
   storageManager,
+  setDataset,
 } from './colorTheme.utils';
 import { ColorTheme, ColorThemeWithSystem } from './colorTheme.types';
 
@@ -35,6 +36,7 @@ function ColorThemeProvider(props: ColorThemeProviderProps) {
     (nextColorTheme: ColorTheme) => {
       setColorTheme(nextColorTheme);
       storageManager.set(nextColorTheme);
+      setDataset(nextColorTheme);
     },
     [getSystemTheme],
   );
@@ -43,14 +45,27 @@ function ColorThemeProvider(props: ColorThemeProviderProps) {
     ? systemColorTheme
     : (colorTheme as ColorTheme);
 
+  // data attributes initalize
+  useEffect(() => {
+    const initColorTheme = colorTheme;
+
+    if (isSystemTheme(initColorTheme)) {
+      const systemTheme = getSystemTheme();
+      setDataset(systemTheme);
+    } else {
+      setDataset(initColorTheme);
+    }
+  }, []);
+
   useMediaQuery(
     PREFER_DARK_QUERY,
     {
       triggerFirstLoad: false,
     },
     (matches) => {
-      if (isSystemTheme(colorTheme))
-        setSystemColorTheme(matches ? COLOR_THEME.DARK : COLOR_THEME.LIGHT);
+      const nextColorTheme = matches ? COLOR_THEME.DARK : COLOR_THEME.LIGHT;
+      setSystemColorTheme(nextColorTheme);
+      setDataset(nextColorTheme);
     },
   );
 

--- a/packages/components/src/ColorTheme/colorTheme.utils.ts
+++ b/packages/components/src/ColorTheme/colorTheme.utils.ts
@@ -34,10 +34,11 @@ const createBrowserStorageManager = (key: string): StorageManager => {
 export const getSystemTheme = () =>
   getMatches(PREFER_DARK_QUERY) ? COLOR_THEME.DARK : COLOR_THEME.LIGHT;
 
-export const isSystemTheme = (theme: ColorThemeWithSystem) =>
+export const isSystemTheme = (theme: ColorThemeWithSystem): theme is 'system' =>
   theme === COLOR_THEME_SYSTEM;
 
-export const isDarkTheme = (theme: ColorTheme) => theme === COLOR_THEME.DARK;
+export const isDarkTheme = (theme: ColorTheme): theme is 'dark' =>
+  theme === COLOR_THEME.DARK;
 
 export const storageManager = createBrowserStorageManager(LOCAL_STORAGE_KEY);
 
@@ -45,3 +46,8 @@ export const getColorTheme = (
   storageManger: StorageManager,
   init: ColorThemeWithSystem,
 ) => storageManger.get(init);
+
+export const setDataset = (theme: ColorTheme) => {
+  if (!isBrowser) return;
+  document.documentElement.setAttribute('data-theme', theme);
+};

--- a/packages/components/src/ColorTheme/index.ts
+++ b/packages/components/src/ColorTheme/index.ts
@@ -1,4 +1,5 @@
 import ColorThemeProvider from './ColorThemeProvider';
 import { useColorTheme } from './colorThemeContext';
+import { setDataset } from './colorTheme.utils';
 
-export { useColorTheme, ColorThemeProvider };
+export { useColorTheme, ColorThemeProvider, setDataset };

--- a/packages/components/src/theme/Button.ts
+++ b/packages/components/src/theme/Button.ts
@@ -1,14 +1,18 @@
+import { ThemePropsWithColorTheme } from '@danji/styled';
+import { createColorByColorTheme } from './theme.utils';
 import { getColorByType } from '../Button/button.utils';
 import { Type } from '../Button/button.types';
 
-const variantSolid = (type: Type) => {
-  const c = getColorByType(type);
+const variantSolid = (themeProps: ThemePropsWithColorTheme) => {
+  const { type, colorTheme } = themeProps;
+  const c = getColorByType(type as Type);
+  const getColor = createColorByColorTheme(colorTheme);
 
   return {
-    bg: `${c}.500`,
+    bg: getColor(`${c}.500`, `${c}.300`),
     color: `white`,
     '&:hover': {
-      backgroundColor: `${c}.600`,
+      backgroundColor: getColor(`${c}.600`, `${c}.400`),
     },
   };
 };

--- a/packages/components/src/theme/Button.ts
+++ b/packages/components/src/theme/Button.ts
@@ -1,24 +1,19 @@
 import { ThemePropsWithColorTheme } from '@danji/styled';
-import { createColorByColorTheme } from './theme.utils';
 import { getColorByType } from '../Button/button.utils';
 import { Type } from '../Button/button.types';
 
-const variantSolid = (themeProps: ThemePropsWithColorTheme) => {
-  const { type, colorTheme } = themeProps;
-  const c = getColorByType(type as Type);
-  const getColor = createColorByColorTheme(colorTheme);
-
-  return {
-    bg: getColor(`${c}.500`, `${c}.300`),
-    color: 'text.primary',
-    '&:hover': {
-      backgroundColor: getColor(`${c}.600`, `${c}.400`),
-    },
-  };
-};
-
 export const variants = {
-  solid: variantSolid,
+  solid: ({ type, switcher: s }: ThemePropsWithColorTheme) => {
+    const c = getColorByType(type as Type);
+
+    return {
+      bg: s(`${c}.500`, `${c}.300`),
+      color: 'text.primary',
+      '&:hover': {
+        backgroundColor: s(`${c}.600`, `${c}.400`),
+      },
+    };
+  },
 };
 
 export const sizes = {

--- a/packages/components/src/theme/Button.ts
+++ b/packages/components/src/theme/Button.ts
@@ -10,7 +10,7 @@ const variantSolid = (themeProps: ThemePropsWithColorTheme) => {
 
   return {
     bg: getColor(`${c}.500`, `${c}.300`),
-    color: `white`,
+    color: 'text.primary',
     '&:hover': {
       backgroundColor: getColor(`${c}.600`, `${c}.400`),
     },

--- a/packages/components/src/theme/theme.utils.ts
+++ b/packages/components/src/theme/theme.utils.ts
@@ -1,0 +1,6 @@
+import { isDarkTheme } from '../ColorTheme/colorTheme.utils';
+import { ColorTheme } from '../ColorTheme/colorTheme.types';
+
+export const createColorByColorTheme =
+  (colorTheme: ColorTheme) => (light: string, black: string) =>
+    isDarkTheme(colorTheme) ? black : light;

--- a/packages/css/src/base.ts
+++ b/packages/css/src/base.ts
@@ -1,14 +1,9 @@
 /* eslint-disable no-restricted-syntax */
-import { getValueByPath, isFunction, isObject } from '@danji/styled';
+import { getValueByPath, callIfFunc, isObject } from '@danji/styled';
 import { EmotionCssObject } from './types';
 import { systemProps } from './system';
 
 export type CSSObject = EmotionCssObject;
-
-const callIfFunc = <T, U extends any[]>(
-  valueOrFunc: T | ((...args: U) => T),
-  ...args: U
-): T => (isFunction(valueOrFunc) ? valueOrFunc(...args) : valueOrFunc);
 
 export const css =
   (stylesOrFunc: any) =>

--- a/packages/css/src/system-props/index.ts
+++ b/packages/css/src/system-props/index.ts
@@ -2,3 +2,4 @@ export { default as aliases } from './aliases';
 export { default as background } from './background';
 export { default as color } from './color';
 export { default as size } from './size';
+export { shouldTransformToVarFunc } from './scales';

--- a/packages/css/src/system-props/scales.ts
+++ b/packages/css/src/system-props/scales.ts
@@ -1,5 +1,6 @@
 import { THEME, isObject, toVarFunc, tokenToCssVar } from '@danji/styled';
 import { ThemeWithCssVars } from '@danji/styled/providers.types';
+import { Dict } from '@danji/styled/base.types';
 import { Transform } from './types';
 
 export const tokens = ['colors', 'sizes'] as const;
@@ -11,10 +12,8 @@ export interface ScaleOpts {
   transform?: Transform;
 }
 
-const shouldTransformToVarFunc = (
-  theme: ThemeWithCssVars<Record<string, any>>,
-  cssVar: string,
-) => isObject(theme.cssVars) && cssVar in theme.cssVars;
+export const shouldTransformToVarFunc = (obj: Dict, cssVar: string) =>
+  isObject(obj) && cssVar in obj;
 
 const tokenToCssVarFunc =
   (scale: ThemeScale, value: string) =>
@@ -22,7 +21,7 @@ const tokenToCssVarFunc =
     const prefix = `${THEME.KEY}-${scale}`;
     const cssVar = tokenToCssVar(value, prefix);
 
-    const transformedValue = shouldTransformToVarFunc(theme, cssVar)
+    const transformedValue = shouldTransformToVarFunc(theme.cssVars, cssVar)
       ? toVarFunc(cssVar)
       : value;
 

--- a/packages/styled/__tests__/theme.test.ts
+++ b/packages/styled/__tests__/theme.test.ts
@@ -230,11 +230,23 @@ describe('getValueByPath', () => {
 
     it('should convert semantic tokens to cssVars', () => {
       const theme = {
+        colors: {
+          gray: {
+            '50': '#f9fafa',
+          },
+          blue: '#007bff',
+        },
         sematicTokens: {
           text: {
             primary: {
               _light: 'black',
               _dark: 'white',
+            },
+          },
+          background: {
+            primary: {
+              _light: 'gray.50',
+              _dark: 'blue',
             },
           },
         },
@@ -244,10 +256,14 @@ describe('getValueByPath', () => {
 
       expect(result).toMatchInlineSnapshot(`
         {
-          "--dj-colors-text-primary": "black",
-          "[data-theme=dark]": {
+          "&[data-theme=dark]": {
+            "--dj-colors-background-primary": "var(--dj-colors-blue)",
             "--dj-colors-text-primary": "white",
           },
+          "--dj-colors-background-primary": "var(--dj-colors-gray-50)",
+          "--dj-colors-blue": "#007bff",
+          "--dj-colors-gray-50": "#f9fafa",
+          "--dj-colors-text-primary": "black",
         }
       `);
     });

--- a/packages/styled/__tests__/utils.test.ts
+++ b/packages/styled/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { isArray, isObject, splitBySeparator } from '@danji/styled/utils';
+import { isArray, isObject, splitBySeparator } from '@danji/styled';
 
 describe('isArray', () => {
   it('should return true if the value is an array', () => {

--- a/packages/styled/src/providers.tsx
+++ b/packages/styled/src/providers.tsx
@@ -6,6 +6,7 @@ import {
   Theme as EmotionTheme,
   ThemeProviderProps as EmotionThemeProviderProps,
 } from '@emotion/react';
+import { shouldTransformToVarFunc } from '@danji/css';
 import {
   THEME,
   TOKEN_ALIASES,
@@ -15,8 +16,9 @@ import {
   pseudoKeys,
   PseudoKeys,
   PseudoAliases,
+  toVarFunc,
 } from './theme';
-import { isNonNull, isObject } from './utils';
+import { isNonNull, isObject, splitBySeparator } from './utils';
 import {
   CssVariablesProps,
   DesignToken,
@@ -53,28 +55,47 @@ function CssVariables({ selector = ':root' }: CssVariablesProps): JSX.Element {
 const createTokensToCssVars = (tokens: DesignTokens) => {
   const target: JSONObject = {};
 
-  const transformValue = (propertyKey: string, propertyValue: DesignToken) =>
-    Object.entries(propertyValue).reduce((acc, [alias, value]) => {
-      if (!isNonNull(value)) return acc;
-
-      const isDefaultAlias = alias === TOKEN_ALIASES.LIGHT;
-      const pseudoClass = isDefaultAlias
-        ? propertyKey
-        : ((TOKEN_PSEUDO_CLASSES as Dict)[alias] as PseudoAliases) ?? alias;
-
-      acc[pseudoClass] = isDefaultAlias ? value : { [propertyKey]: value };
-
-      return acc;
-    }, {} as JSONObject);
-
-  Object.entries(tokens).forEach(([token, value]) => {
+  Object.entries(tokens).forEach(([token, rawValue]) => {
     const key = tokenToCssVar(token, THEME.KEY);
 
-    const normalizeValue = isObject(value)
-      ? value
-      : { [TOKEN_ALIASES.LIGHT]: value };
+    const designToken = isObject(rawValue)
+      ? rawValue
+      : { [TOKEN_ALIASES.LIGHT]: rawValue };
 
-    const source = transformValue(key, normalizeValue as DesignToken);
+    const getNormalizedValue = (value: string) => {
+      const separator = '.';
+      const scale = splitBySeparator(token, separator)[0];
+      const valueWithScale = `${scale}${separator}${value}`;
+
+      if (shouldTransformToVarFunc(tokens, valueWithScale)) {
+        const cssVar = tokenToCssVar(valueWithScale, THEME.KEY);
+        return toVarFunc(cssVar);
+      }
+
+      return value;
+    };
+
+    const transformValue = (propertyKey: string, propertyValue: DesignToken) =>
+      Object.entries(propertyValue).reduce((acc, [alias, value]) => {
+        if (!isNonNull(value)) return acc;
+
+        const isDefaultAlias = alias === TOKEN_ALIASES.LIGHT;
+        const pseudoClass = isDefaultAlias
+          ? propertyKey
+          : ((TOKEN_PSEUDO_CLASSES as Dict)[alias] as PseudoAliases) ?? alias;
+
+        const normalizedValue = getNormalizedValue(value);
+
+        acc[pseudoClass] = isDefaultAlias
+          ? normalizedValue
+          : {
+              [propertyKey]: normalizedValue,
+            };
+
+        return acc;
+      }, {} as JSONObject);
+
+    const source = transformValue(key, designToken);
 
     Object.assign(target, source);
   });

--- a/packages/styled/src/providers.tsx
+++ b/packages/styled/src/providers.tsx
@@ -89,6 +89,7 @@ const createTokensToCssVars = (tokens: DesignTokens) => {
         acc[pseudoClass] = isDefaultAlias
           ? normalizedValue
           : {
+              ...((target[pseudoClass] || {}) as object),
               [propertyKey]: normalizedValue,
             };
 

--- a/packages/styled/src/theme/constants.ts
+++ b/packages/styled/src/theme/constants.ts
@@ -18,7 +18,7 @@ export const TOKEN_ALIASES = {
 } as const;
 
 export const TOKEN_PSEUDO_CLASSES = {
-  [TOKEN_ALIASES.DARK]: '[data-theme=dark]',
+  [TOKEN_ALIASES.DARK]: '&[data-theme=dark]',
 } as const;
 
 export type PseudoKeys = keyof typeof TOKEN_PSEUDO_CLASSES;

--- a/packages/styled/src/theme/hooks.ts
+++ b/packages/styled/src/theme/hooks.ts
@@ -1,9 +1,10 @@
 import { ThemeContext as EmotionThemeContext } from '@emotion/react';
 import { useContext } from 'react';
 import { useColorTheme } from '@danji/components';
-import { ColorTheme } from '@danji/components/ColorTheme/colorTheme.types';
+import { createColorByColorTheme } from '@danji/components/theme/theme.utils';
 import { ThemeWithCssVars } from '../providers.types';
 import { getValueByPath } from './base';
+import { callIfFunc } from '../utils';
 
 /**
  * @todo 각 컴포넌트 사이즈, 타입에 정의 매칭되도록 수정
@@ -15,7 +16,7 @@ interface ThemeProps {
 }
 
 export type ThemePropsWithColorTheme = ThemeProps & {
-  colorTheme: ColorTheme;
+  switcher: (light: string, black: string) => string;
 };
 
 const useTheme = <T extends Record<string, any>>() => {
@@ -29,9 +30,10 @@ const useTheme = <T extends Record<string, any>>() => {
 export const useThemeStyles = (themeKey: string, props: ThemeProps) => {
   const theme = useTheme();
   const { colorTheme } = useColorTheme();
+  const switcher = createColorByColorTheme(colorTheme);
   const styles = {};
   const themeProps = {
-    colorTheme,
+    switcher,
     ...props,
   } as ThemePropsWithColorTheme;
 
@@ -39,8 +41,8 @@ export const useThemeStyles = (themeKey: string, props: ThemeProps) => {
 
   if (themeStyleConfig) {
     Object.assign(styles, {
-      ...themeStyleConfig.sizes[themeProps.size],
-      ...themeStyleConfig.variants[themeProps.variant](themeProps),
+      ...callIfFunc(themeStyleConfig.sizes[themeProps.size], themeProps),
+      ...callIfFunc(themeStyleConfig.variants[themeProps.variant], themeProps),
     });
   }
 

--- a/packages/styled/src/theme/hooks.ts
+++ b/packages/styled/src/theme/hooks.ts
@@ -1,5 +1,7 @@
 import { ThemeContext as EmotionThemeContext } from '@emotion/react';
 import { useContext } from 'react';
+import { useColorTheme } from '@danji/components';
+import { ColorTheme } from '@danji/components/ColorTheme/colorTheme.types';
 import { ThemeWithCssVars } from '../providers.types';
 import { getValueByPath } from './base';
 
@@ -12,6 +14,10 @@ interface ThemeProps {
   type: string;
 }
 
+export type ThemePropsWithColorTheme = ThemeProps & {
+  colorTheme: ColorTheme;
+};
+
 const useTheme = <T extends Record<string, any>>() => {
   const ctx = useContext(EmotionThemeContext);
 
@@ -22,15 +28,19 @@ const useTheme = <T extends Record<string, any>>() => {
 
 export const useThemeStyles = (themeKey: string, props: ThemeProps) => {
   const theme = useTheme();
-  const { variant, size, type } = props;
+  const { colorTheme } = useColorTheme();
   const styles = {};
+  const themeProps = {
+    colorTheme,
+    ...props,
+  } as ThemePropsWithColorTheme;
 
   const themeStyleConfig = getValueByPath(theme, `components.${themeKey}`);
 
   if (themeStyleConfig) {
     Object.assign(styles, {
-      ...themeStyleConfig.sizes[size],
-      ...themeStyleConfig.variants[variant](type),
+      ...themeStyleConfig.sizes[themeProps.size],
+      ...themeStyleConfig.variants[themeProps.variant](themeProps),
     });
   }
 

--- a/packages/styled/src/theme/hooks.ts
+++ b/packages/styled/src/theme/hooks.ts
@@ -3,6 +3,15 @@ import { useContext } from 'react';
 import { ThemeWithCssVars } from '../providers.types';
 import { getValueByPath } from './base';
 
+/**
+ * @todo 각 컴포넌트 사이즈, 타입에 정의 매칭되도록 수정
+ */
+interface ThemeProps {
+  variant: string;
+  size: string;
+  type: string;
+}
+
 const useTheme = <T extends Record<string, any>>() => {
   const ctx = useContext(EmotionThemeContext);
 
@@ -11,7 +20,7 @@ const useTheme = <T extends Record<string, any>>() => {
   return ctx as ThemeWithCssVars<T>;
 };
 
-export const useThemeStyles = (themeKey: string, props: any) => {
+export const useThemeStyles = (themeKey: string, props: ThemeProps) => {
   const theme = useTheme();
   const { variant, size, type } = props;
   const styles = {};

--- a/packages/styled/src/utils/coreUtils.ts
+++ b/packages/styled/src/utils/coreUtils.ts
@@ -1,0 +1,6 @@
+import { isFunction } from './assertion';
+
+export const callIfFunc = <T, U extends any[]>(
+  valueOrFunc: T | ((...args: U) => T),
+  ...args: U
+): T => (isFunction(valueOrFunc) ? valueOrFunc(...args) : valueOrFunc);

--- a/packages/styled/src/utils/index.ts
+++ b/packages/styled/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './strUtils';
 export * from './arrayUtils';
+export * from './coreUtils';
 export * from './assertion';

--- a/packages/styled/src/variables.ts
+++ b/packages/styled/src/variables.ts
@@ -1,6 +1,4 @@
 export const colors = {
-  white: '#f6f6f6',
-  black: '#1f2123',
   whiteAlpha: {
     '50': 'rgba(255, 255, 255, 0.04)',
     '100': 'rgba(255, 255, 255, 0.06)',
@@ -150,8 +148,8 @@ export const colors = {
 export const sematicTokens = {
   text: {
     primary: {
-      _light: 'black',
-      _dark: 'white',
+      _light: 'whiteAlpha.800',
+      _dark: 'whiteAlpha.900',
     },
   },
 };


### PR DESCRIPTION
### Description
- 테마 변경 시, data-attributes가 변경되도록 기능 수정
- 시멘틱 토큰의 값이 토큰인 경우 토큰에 맞는 값으로 적용되도록 기능 수정
- 테마에 맞는 색상을 정의하면 테마가 변경될 때, 적용되도록 컴포넌트 기능 수정

|  Light                             |  Dark                             |
| ---------------------- | ---------------------- |
| ![light](https://github.com/Gganbu-UI/danji/assets/53927959/58039c70-36d7-46fe-8393-b87ee70db37e) | ![dark](https://github.com/Gganbu-UI/danji/assets/53927959/47aada0c-d083-49c5-b199-bf9b02eb1590) |

### Checklist

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
